### PR TITLE
Add missing ignition provider section to ignition.tf

### DIFF
--- a/machine/ignition.tf
+++ b/machine/ignition.tf
@@ -1,3 +1,7 @@
+provider "ignition" {
+  version = "1.1.0"
+}
+
 locals {
   mask = "${element(split("/", var.machine_cidr), 1)}"
   gw   = "192.168.1.1"


### PR DESCRIPTION
When running terraform plan, we were running into errors.
See error message received quoted below.
Adding the terraform provider section for ignition fixes it.

```
Error: Error refreshing state: 3 error(s) occurred:

* module.bootstrap.data.ignition_config.ign: 1 error(s) occurred:
* module.bootstrap.data.ignition_config.ign: data.ignition_config.ign: No valid JSON found, make sure you're using .rendered and not .id: invalid character 'b' after top-level value

* module.control_plane.data.ignition_config.ign: 3 error(s) occurred:
* module.control_plane.data.ignition_config.ign[0]: data.ignition_config.ign.0: No valid JSON found, make sure you're using .rendered and not .id: invalid character 'c' after top-level value
* module.control_plane.data.ignition_config.ign[1]: data.ignition_config.ign.1: No valid JSON found, make sure you're using .rendered and not .id: invalid character 'b' in literal false (expecting 'a')
* module.control_plane.data.ignition_config.ign[2]: data.ignition_config.ign.2: No valid JSON found, make sure you're using .rendered and not .id: invalid character 'b' after top-level value

* module.compute.data.ignition_config.ign: 3 error(s) occurred:
* module.compute.data.ignition_config.ign[2]: data.ignition_config.ign.2: No valid JSON found, make sure you're using .rendered and not .id: invalid character 'c' looking for beginning of value
* module.compute.data.ignition_config.ign[1]: data.ignition_config.ign.1: No valid JSON found, make sure you're using .rendered and not .id: invalid character 'e' after top-level value
* module.compute.data.ignition_config.ign[0]: data.ignition_config.ign.0: No valid JSON found, make sure you're using .rendered and not .id: invalid character 'c' after top-level value
```

Ref:
https://github.com/openshift/installer/commit/258e361c61e81a7401cd3390da23a7091a9531fb